### PR TITLE
Fix for the issue with the table width

### DIFF
--- a/style.css
+++ b/style.css
@@ -41,7 +41,6 @@ a:hover {
 }
 
 table {
-	display: block;
 	padding-top: 30px;
 	margin: auto;
 	width: 70%;
@@ -54,7 +53,7 @@ table {
 }
 
 .cataloglist {
-    text-align: center;
+  text-align: center;
 	border-spacing: 0 3px;
 }
 


### PR DESCRIPTION
Tables have their own display type of `table`, overriding this with `display: block;` causes them to act like normal block level divs and thus only fill out to what information is available to them, unless you float them.
